### PR TITLE
Allow skipping unknown fields

### DIFF
--- a/pkg/decodini/decode.go
+++ b/pkg/decodini/decode.go
@@ -22,6 +22,11 @@ type Decoding struct {
 	// Decoder is a custom decoder. If nil is returned, the default decoding
 	// mechanism is used.
 	Decoder func(tr *Tree, target DecodeTarget) Decoder
+
+	// SkipUnknownFields specifies whether the decoder should ignore entries whose
+	// name cannot be mapped to a field in the target struct. This allows decoding
+	// into structs that contain fewer fields than the original input.
+	SkipUnknownFields bool
 }
 
 var defaultDecoding = Decoding{

--- a/pkg/decodini/decode_test.go
+++ b/pkg/decodini/decode_test.go
@@ -576,7 +576,7 @@ func TestDecode_Map_SkipUnknownFields(t *testing.T) {
 	t.Parallel()
 
 	dec := &Decoding{
-		SkipUnknownFields: true,
+		ResolveUnknownField: DecodeIgnoreUnknownField,
 	}
 
 	val := map[string]any{
@@ -654,7 +654,7 @@ func TestDecode_Struct_SkipUnknownFields(t *testing.T) {
 	t.Parallel()
 
 	dec := &Decoding{
-		SkipUnknownFields: true,
+		ResolveUnknownField: DecodeIgnoreUnknownField,
 	}
 
 	type testStruct struct {

--- a/pkg/decodini/decoder_map.go
+++ b/pkg/decodini/decoder_map.go
@@ -72,6 +72,9 @@ func (d *MapDecoder) decodeIntoStruct(tr *Tree, target DecodeTarget) error {
 	for _, child := range tr.Children {
 		sf, vf := d.dec.structFieldByName(created, fmt.Sprint(child.Name()))
 		if !vf.IsValid() {
+			if d.dec.SkipUnknownFields {
+				continue
+			}
 			return newDecodeErrorf(tr.Path, "no such field: %s in %s", child.Name(), typ)
 		}
 

--- a/pkg/decodini/decoder_slice.go
+++ b/pkg/decodini/decoder_slice.go
@@ -33,16 +33,11 @@ func (d *SliceDecoder) Decode(tr *Tree, target DecodeTarget) error {
 }
 
 func (d *SliceDecoder) decodeIntoSlice(tr *Tree, target DecodeTarget) error {
-	var typ reflect.Type
-	if target.Value.Kind() == reflect.Interface {
-		typ = tr.Value.Type()
-	} else {
-		typ = target.Value.Type()
-	}
+	typ := inferType(tr, target)
 	created := reflect.MakeSlice(typ, len(tr.Children), len(tr.Children))
 
 	for i, child := range tr.Children {
-		subtarget := DecodeTarget{Value: created.Index(i), sliceIndex: &i}
+		subtarget := DecodeTarget{Parent: &target, Value: created.Index(i), sliceIndex: &i}
 		if err := d.dec.decode(append(tr.Path, i), child, subtarget); err != nil {
 			return err
 		}

--- a/pkg/decodini/decoder_struct.go
+++ b/pkg/decodini/decoder_struct.go
@@ -51,7 +51,9 @@ func (d *StructDecoder) decodeIntoStruct(tr *Tree, target DecodeTarget) error {
 
 		sf, field := d.dec.structFieldByName(created.Elem(), name)
 		if !field.IsValid() {
-			// TODO: allow ignoring fields
+			if d.dec.SkipUnknownFields {
+				continue
+			}
 			return newDecodeErrorf(tr.Path, "struct field %s does not exist", name)
 		}
 

--- a/pkg/decodini/encode.go
+++ b/pkg/decodini/encode.go
@@ -49,7 +49,10 @@ func (e *Encoding) encode(path []any, val reflect.Value) *Tree {
 		}
 		return e.encode(path, val.Elem())
 	default:
-		panic(fmt.Sprintf("unsupported kind %s for value %v", val.Kind(), val.Interface()))
+		if val.CanInterface() {
+			panic(fmt.Sprintf("unsupported kind %s for value %v", val.Kind(), val.Interface()))
+		}
+		panic(fmt.Sprintf("unsupported kind %s", val.Kind()))
 	}
 }
 

--- a/pkg/decodini/encode.go
+++ b/pkg/decodini/encode.go
@@ -43,8 +43,13 @@ func (e *Encoding) encode(path []any, val reflect.Value) *Tree {
 		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return e.encodeScalar(path, val)
+	case reflect.Interface:
+		if val.IsNil() {
+			return NewTree(path, val)
+		}
+		return e.encode(path, val.Elem())
 	default:
-		panic(fmt.Sprintf("unsupported kind %s", val.Kind()))
+		panic(fmt.Sprintf("unsupported kind %s for value %v", val.Kind(), val.Interface()))
 	}
 }
 


### PR DESCRIPTION
This PR implements the ability for clients to decide to skip unknown fields. So far, the decoder returned an error when it could not find a struct field into which to decode a tree.